### PR TITLE
ci: add new pr title requirement workflow

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,22 @@
+name: pr-title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate semantic PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          subjectPattern: "^(.*) AB#[0-9]+$"
+          subjectPatternError: |
+            The subject: "{subject}" in the pull request with title: "{title}" does not match the required pattern.
+            Please ensure the title ends with "AB#<HU-ID>", where <HU-ID> is the Azure DevOps work item ID related to this change.


### PR DESCRIPTION
# Rationale

Introduces a GitHub Actions workflow to enforce a standardized format for Pull Request titles across the organization.

All PR titles must follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification and additionally end with `AB#<HU-ID>`, where `<HU-ID>` is the Azure DevOps task ID associated with the work. For example:
```
feat(routes): add new /users route to merchant users [AB#123](https://dev.azure.com/wompi-co/e4538663-13b6-40f0-948d-94024707b88f/_workitems/edit/123)
```

# Discussion

N/A

# Affected Components 

+ `.github/workflows/pr-title.yaml` - Adds new workflow

# Security Concerns

N/A

# Impact Documentation

The authorized party responsible for applying/releasing approved changes to the system must follow these steps:

1. Identify clearly the components affected in the deployment
-  A new GitHub actions to enforce internal guidelines is added, no infrastructure or software is modified.
2. According to the components impacted identify in Wompi value chain the improvements proposed:
    1. Transactional Processing
    - N/A
    2. Fraud Prevention
    - N/A
    3. Cybersecurity
        1. Threat Prevention
        - N/A
        2. Vulnerability Fixing
        - N/A
    4. Vendor specific
        1. New vendor onboarding or integration
        - N/A
        2. Obsolete vendor removal and resources deletion
        - N/A
        3. Shared responsibility model compliance (e.g. AWS)
        - N/A
3. Sign off with a conclusion and compliance with all applicable guidelines

This change introduces a standardized process for PR title formatting, ensuring consistency and traceability across the organization. The workflow does not impact infrastructure or application code, and complies with all internal guidelines.